### PR TITLE
Compile to BS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,6 @@ _build/**
 *.run
 *.opt
 *.native
-node_modules
+*.log
+/node_modules/
+/lib/

--- a/_tags
+++ b/_tags
@@ -1,1 +1,2 @@
 <node_modules>: -traverse
+<lib>: -traverse

--- a/bsconfig.json
+++ b/bsconfig.json
@@ -1,0 +1,24 @@
+{
+  "name": "Immutable.re",
+  "sources": [
+    {
+      "dir": "immutable",
+      "subdirs": [
+        {
+          "dir": "src",
+          "subdirs": ["collection", "core", "extra", "indexed", "keyed", "utils"],
+        },
+        {
+          "dir": "test",
+        },
+        {
+          "dir": "perf",
+        },
+      ],
+    },
+    {
+      "dir": "reUnit",
+      "subdirs": ["src"],
+    },
+  ],
+}

--- a/package.json
+++ b/package.json
@@ -34,10 +34,12 @@
     "top": "eval $(dependencyEnv) && rtop",
     "env": "eval $(dependencyEnv) && env",
     "editor": "eval $(dependencyEnv) && eval $EDITOR",
-    "whereisocamlmerlin": "eval $(dependencyEnv) && which ocamlmerlin-reason"
+    "whereisocamlmerlin": "eval $(dependencyEnv) && which ocamlmerlin-reason",
+    "build-js": "bsb"
   },
   "devDependencies": {
-      "@opam-alpha/merlin": "^ 2.5.0"
+      "@opam-alpha/merlin": "^ 2.5.0",
+      "bs-platform": "^1.5.0"
     },
   "dependencies": {
     "ocamlBetterErrors": "0.1.0",


### PR DESCRIPTION
There are two errors (both legit I think) and lots of warnings. BS enables/disables a set of warnings that ocamlc couldn't have as default because of legacy.