### PR TITLE
Upgrade BetterErrors & Merlin

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,11 +38,11 @@
     "build-js": "bsb"
   },
   "devDependencies": {
-      "@opam-alpha/merlin": "^ 2.5.0",
+      "@opam-alpha/merlin": "^ 2.5.1",
       "bs-platform": "^1.5.0"
     },
   "dependencies": {
-    "ocamlBetterErrors": "0.1.0",
+    "ocamlBetterErrors": "0.1.1",
     "reason": "^ 1.6.0",
     "@opam-alpha/ocaml": "4.2.3",
     "dependency-env": "^0.1.1",


### PR DESCRIPTION
New BE patch tracks reason stable, instead of master.
Merlin actually needs to be 2.5.1 to have the Reason support.