### PR TITLE
Increase build speed for users by making tests a dev type.

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -11,15 +11,18 @@
         {
           "dir": "test",
           "subdirs": ["testers"],
+          "type": "dev",
         },
         {
           "dir": "perf",
+          "type": "dev",
         },
       ],
     },
     {
       "dir": "reUnit",
       "subdirs": ["src"],
+      "type": "dev",
     },
   ],
 }


### PR DESCRIPTION
Dev types don't get build when a project is used as library. This
decreases build times from ~4s to ~2.7s on my macbook air.