### PR TITLE
Relax the ocaml version constrain in opam

### DIFF
--- a/opam
+++ b/opam
@@ -15,6 +15,6 @@ build: [
 ]
 depends: [
   "topkg"       {=  "0.8.1"}
-  "reason"      {=  "1.13.0"}
+  "reason"      {=  "1.13.3"}
 ]
-available: [ ocaml-version >= "4.02" & ocaml-version < "4.03" ]
+available: [ ocaml-version >= "4.02" & ocaml-version < "4.05" ]

--- a/opam.in
+++ b/opam.in
@@ -14,6 +14,6 @@ build: [
 ]
 depends: [
   "topkg"       {=  "0.8.1"}
-  "reason"      {=  "1.13.0"}
+  "reason"      {=  "1.13.3"}
 ]
-available: [ ocaml-version >= "4.02" & ocaml-version < "4.03" ]
+available: [ ocaml-version >= "4.02" & ocaml-version < "4.05" ]


### PR DESCRIPTION
We published a new minor version of reason which supports both 4.04 and 4.03. This enables immutable-re to be available on those versions as well. 