### PR TITLE
Turn off warnings in bsconfig

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -18,4 +18,7 @@
     { "dir": "test", "subdirs": ["testers"], "type": "dev" },
     { "dir": "perf-js", "type": "dev" },
   ],
+  "warnings": {
+    "number": "a",
+  },
 }

--- a/bsconfig.json
+++ b/bsconfig.json
@@ -19,6 +19,6 @@
     { "dir": "perf-js", "type": "dev" },
   ],
   "warnings": {
-    "number": "a",
+    "number": "-8-27",
   },
 }


### PR DESCRIPTION
I tried `immutable-re` in BS project but see tons of warnings (really a lot) like unused variables or unhandled possible cases in PM. This PR turns warnings off in bsconfig.

Also, from @jordwalke on Discord:
> It could just be that its bsconfig isn’t updated to reflect its native compilation config.

I'd fix the warnings instead of turning them off tbh but I have zero experience w/ native ocaml and have no idea where to start w/ this issue.