### PR TITLE
Upgrade bs-platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/facebookincubator/immutable-re.git"
   },
   "dependencies": {
-    "bs-platform": "^2.2.1"
+    "bs-platform": "^4.0.17"
   },
   "devDependencies": {
     "immutable": "^3.8.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/facebookincubator/immutable-re.git"
   },
   "dependencies": {
-    "bs-platform": "^4.0.17"
+    "bs-platform": "^4.0.6"
   },
   "devDependencies": {
     "immutable": "^3.8.1",


### PR DESCRIPTION
Upgrading `bs-platform` to solve issue with multiple bs-platform in `reductive`:
https://github.com/reasonml-community/reductive/issues/39 

Is it possible? Will it affect this library in any way?